### PR TITLE
Remove songs from compilations from produced playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Next steps include:
 * Incorporate batch insertion of songs into SQL database through the ORM
 * Develop asynchronous solution so we don't have to wait for network requests to complete to move onto the next network request to substantially decrease runtime
 
+* Abstract spotify calls
+
 ## To set up on your local machine
 
 This app requires you to have an API Key and Secret from Spotify, and to set up a `.env` file in the root of your directory with the following information:

--- a/app/models/destination_playlist.rb
+++ b/app/models/destination_playlist.rb
@@ -3,6 +3,7 @@ class DestinationPlaylist < ApplicationRecord
 
   def add_songs(songs, token)
     i = 0
+    songs = songs.not_compilation
     while songs.length > i do
       body = {"uris": songs.slice(i, 100).map{|song| song.uri}}.to_json
       response = `curl -i -X POST \

--- a/app/models/destination_playlist.rb
+++ b/app/models/destination_playlist.rb
@@ -3,7 +3,7 @@ class DestinationPlaylist < ApplicationRecord
 
   def add_songs(songs, token)
     i = 0
-    songs = songs.not_compilation
+    songs = songs
     while songs.length > i do
       body = {"uris": songs.slice(i, 100).map{|song| song.uri}}.to_json
       response = `curl -i -X POST \
@@ -35,7 +35,7 @@ class DestinationPlaylist < ApplicationRecord
 
   def self.create_user_playlists(user)
     token = user.get_new_token
-    grouped_by_year = Song.by_year(user.songs)
+    grouped_by_year = Song.by_year(user.songs.not_compilation)
     years = grouped_by_year.keys.select{|key| key != "not_sorted"}.sort_by{|a, b| b.to_i - a.to_i}
     years.each do |year|
       playlist = user.make_playlist(grouped_by_year[year], year, token)

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -2,6 +2,12 @@ class Song < ApplicationRecord
   belongs_to :spotify_source_playlist
   belongs_to :user
 
+  scope :not_compilation, -> {where.not(album_type: "compilation").or(Song.where(album_type: nil))}
+
+  def get_self
+    SpotifyApi.get(user, "/tracks/#{spotify_id}")
+  end
+
   def self.by_year(songs)
     songs.group_by{|s| s.release_date ? s.release_date.year : "not_sorted"}
   end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -3,6 +3,7 @@ class Song < ApplicationRecord
   belongs_to :user
 
   scope :not_compilation, -> {where.not(album_type: "compilation").or(Song.where(album_type: nil))}
+  scope :in_year, -> (year){where("release_date >= ? AND release_date <= ?", DateTime.new(year), DateTime.new(year + 1))}
 
   def get_self
     SpotifyApi.get(user, "/tracks/#{spotify_id}")

--- a/app/models/spotify_source_playlist.rb
+++ b/app/models/spotify_source_playlist.rb
@@ -1,5 +1,22 @@
 class SpotifySourcePlaylist < ApplicationRecord
   belongs_to :user
+  has_many :songs
+
+
+  def get_self
+    SpotifyApi.get(user, "/playlists/#{spotify_id}")
+  end
+
+  def get_tracks
+    SpotifyApi.get(user, "/playlists/#{spotify_id}/tracks")
+  end
+
+  def get_songs_without_token
+    get_songs(user.get_new_token)
+  end
+
+
+  # Token-Dependent
 
   def get_songs(token)
     total_songs = fetch_songs(token, 0)
@@ -27,6 +44,7 @@ class SpotifySourcePlaylist < ApplicationRecord
           end
           s.artist = track["artists"][0]["name"]
           s.album = track["album"]["name"]
+          s.album_type = track["album"]["album_type"]
           s.uri = track["uri"]
           s.user = user
           s.spotify_source_playlist = self
@@ -67,5 +85,6 @@ class SpotifySourcePlaylist < ApplicationRecord
       p.user = user
     end
   end
+
 
 end

--- a/app/models/spotify_source_playlist.rb
+++ b/app/models/spotify_source_playlist.rb
@@ -28,9 +28,13 @@ class SpotifySourcePlaylist < ApplicationRecord
   end
 
   def fetch_songs(token, offset)
-    res = JSON.parse(`curl -H "Authorization: Bearer #{token}" https://api.spotify.com/v1/playlists/#{spotify_id}/tracks?offset=#{offset}`)
-    save_songs(res)
-    return res["total"]
+    res = SpotifyApi.get_with_token(token, "/playlists/#{spotify_id}/tracks?offset=#{offset}`")
+    if res
+      save_songs(res)
+      return res["total"]
+    else
+      return 0
+    end
   end
 
   def save_songs(res)
@@ -67,9 +71,7 @@ class SpotifySourcePlaylist < ApplicationRecord
   end
 
   def self.get_by_token_and_offset(token, offset)
-    route = "https://api.spotify.com/v1/me/playlists?offset=#{offset}"
-    response = JSON.parse(`curl -H "Authorization: Bearer #{token}" #{route}`)
-    return response
+    SpotifyApi.get_with_token(token, "/me/playlists?offset=#{offset}")
   end
 
   def self.create_playlists(playlists, user)

--- a/app/services/SpotifyApi.rb
+++ b/app/services/SpotifyApi.rb
@@ -1,0 +1,7 @@
+class SpotifyApi
+
+  def self.get(user, endpoint)
+    JSON.parse(`curl -H "Authorization: Bearer #{user.get_new_token}" https://api.spotify.com/v1#{endpoint}`)
+  end
+
+end

--- a/app/services/SpotifyApi.rb
+++ b/app/services/SpotifyApi.rb
@@ -4,4 +4,18 @@ class SpotifyApi
     JSON.parse(`curl -H "Authorization: Bearer #{user.get_new_token}" https://api.spotify.com/v1#{endpoint}`)
   end
 
+  def self.get_with_token(token, endpoint)
+    res = `curl -H "Authorization: Bearer #{token}" https://api.spotify.com/v1#{endpoint}`
+    if res != ""
+      JSON.parse(res)
+    else
+      res = `curl -H "Authorization: Bearer #{token}" https://api.spotify.com/v1#{endpoint}`
+      if res != ""
+        JSON.parse(res)
+      else
+        puts "Giving up on #{endpoint}"
+      end
+    end
+  end
+
 end

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.logger = nil

--- a/db/migrate/20210815215411_add_album_type_to_song.rb
+++ b/db/migrate/20210815215411_add_album_type_to_song.rb
@@ -1,0 +1,5 @@
+class AddAlbumTypeToSong < ActiveRecord::Migration[6.0]
+  def change
+    add_column :songs, :album_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_06_203530) do
+ActiveRecord::Schema.define(version: 2021_08_15_215411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2020_10_06_203530) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "album_type"
     t.index ["spotify_source_playlist_id"], name: "index_songs_on_spotify_source_playlist_id"
     t.index ["user_id"], name: "index_songs_on_user_id"
   end


### PR DESCRIPTION
Noticed in completed playlists a large number of songs from compilations that had originally been released in other years. These now no longer get added to the completed playlists.